### PR TITLE
printbuf.c: Fix for implicit declaration of function 'vasprintf'

### DIFF
--- a/printbuf.c
+++ b/printbuf.c
@@ -15,6 +15,7 @@
 
 #include "config.h"
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Using the same q'n'd fix from eabae907c9d991143e17da278a239819f2e8ae1c for *printbuf.c* as well.

Q'n'D because there are systems who don't support `_GNU_SOURCE`. They won't like such hard coded defines.