### PR TITLE
provide consistent external namespace fjson_*

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,8 @@ libfastjsoninclude_HEADERS = \
 #libjsonx_include_HEADERS = \
 #	json_config.h
 
-libfastjson_la_LDFLAGS = -version-info 3:0:0 -no-undefined @JSON_BSYMBOLIC_LDFLAGS@
+libfastjson_la_LDFLAGS = -version-info 3:0:0 -no-undefined @JSON_BSYMBOLIC_LDFLAGS@ \
+	-export-symbols-regex '^fjson_.*'
 libfastjson_la_CPPFLAGS = -Werror
 
 libfastjson_la_SOURCES = \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,6 +23,9 @@ TESTS+= test_set_serializer.test
 check_PROGRAMS=
 check_PROGRAMS += $(TESTS:.test=)
 
+test_printbuf_SOURCES = test_printbuf.c ../printbuf.c ../debug.c
+test_set_serializer_SOURCES = test_set_serializer.c ../printbuf.c
+
 # Note: handled by test1.test
 check_PROGRAMS += test1Formatted 
 test1Formatted_SOURCES = test1.c parse_flags.c parse_flags.h


### PR DESCRIPTION
Only export symbols from this name space. Note that this may
currently block some functionality actually required by user
programs. We will work towards checking and potentially
re-enabling and renaming this shortly. For now, it's important
to set the baseline. In theory, all that really should be
API should be covered by this change.

closes https://github.com/rsyslog/libfastjson/issues/11