### PR TITLE
change macro names from FJSON_C_ to FJSON_

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ AC_CONFIG_HEADER(config.h)
 AC_CONFIG_HEADER(json_config.h)
 AC_HEADER_STDC
 AC_CHECK_HEADERS(fcntl.h limits.h strings.h syslog.h unistd.h [sys/cdefs.h] [sys/param.h] stdarg.h locale.h endian.h)
-AC_CHECK_HEADER(inttypes.h,[AC_DEFINE([FJSON_C_HAVE_INTTYPES_H],[1],[Public define for json_inttypes.h])])
+AC_CHECK_HEADER(inttypes.h,[AC_DEFINE([FJSON_HAVE_INTTYPES_H],[1],[Public define for json_inttypes.h])])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/json_c_version.c
+++ b/json_c_version.c
@@ -10,11 +10,11 @@
 
 const char *fjson_c_version(void)
 {
-	return FJSON_C_VERSION;
+	return FJSON_VERSION;
 }
 
 int fjson_c_version_num(void)
 {
-	return FJSON_C_VERSION_NUM;
+	return FJSON_VERSION_NUM;
 }
 

--- a/json_c_version.h
+++ b/json_c_version.h
@@ -8,15 +8,15 @@
 #ifndef _fj_json_c_version_h_
 #define _fj_json_c_version_h_
 
-#define FJSON_C_MAJOR_VERSION 0
-#define FJSON_C_MINOR_VERSION 12
-#define FJSON_C_MICRO_VERSION 99
-#define FJSON_C_VERSION_NUM ((FJSON_C_MAJOR_VERSION << 16) | \
-                            (FJSON_C_MINOR_VERSION << 8) | \
-                            FJSON_C_MICRO_VERSION)
-#define FJSON_C_VERSION "0.12.99"
+#define FJSON_MAJOR_VERSION 0
+#define FJSON_MINOR_VERSION 12
+#define FJSON_MICRO_VERSION 99
+#define FJSON_VERSION_NUM ((FJSON_MAJOR_VERSION << 16) | \
+                            (FJSON_MINOR_VERSION << 8) | \
+                            FJSON_MICRO_VERSION)
+#define FJSON_VERSION "0.12.99"
 
-const char *fjson_c_version(void); /* Returns FJSON_C_VERSION */
-int fjson_c_version_num(void);     /* Returns FJSON_C_VERSION_NUM */
+const char *fjson_c_version(void); /* Returns FJSON_VERSION */
+int fjson_c_version_num(void);     /* Returns FJSON_VERSION_NUM */
 
 #endif

--- a/json_inttypes.h
+++ b/json_inttypes.h
@@ -4,7 +4,7 @@
 
 #include "json_config.h"
 
-#ifdef FJSON_C_HAVE_INTTYPES_H
+#ifdef FJSON_HAVE_INTTYPES_H
 /* inttypes.h includes stdint.h */
 #include <inttypes.h>
 

--- a/json_object.c
+++ b/json_object.c
@@ -356,14 +356,14 @@ const char* fjson_object_to_json_string_ext(struct fjson_object *jso, int flags)
 
 const char* fjson_object_to_json_string(struct fjson_object *jso)
 {
-	return fjson_object_to_json_string_ext(jso, FJSON_C_TO_STRING_SPACED);
+	return fjson_object_to_json_string_ext(jso, FJSON_TO_STRING_SPACED);
 }
 
 static void indent(struct printbuf *pb, int level, int flags)
 {
-	if (flags & FJSON_C_TO_STRING_PRETTY)
+	if (flags & FJSON_TO_STRING_PRETTY)
 	{
-		if (flags & FJSON_C_TO_STRING_PRETTY_TAB)
+		if (flags & FJSON_TO_STRING_PRETTY_TAB)
 		{
 			printbuf_memset(pb, -1, '\t', level);
 		}
@@ -385,23 +385,23 @@ static int fjson_object_object_to_json_string(struct fjson_object* jso,
 	struct fjson_object_iter iter;
 
 	printbuf_memappend_char(pb, '{' /*}*/);
-	if (flags & FJSON_C_TO_STRING_PRETTY)
+	if (flags & FJSON_TO_STRING_PRETTY)
 		printbuf_memappend_char(pb, '\n');
 	fjson_object_object_foreachC(jso, iter)
 	{
 		if (had_children)
 		{
 			printbuf_memappend_char(pb, ',');
-			if (flags & FJSON_C_TO_STRING_PRETTY)
+			if (flags & FJSON_TO_STRING_PRETTY)
 				printbuf_memappend_char(pb, '\n');
 		}
 		had_children = 1;
-		if (flags & FJSON_C_TO_STRING_SPACED)
+		if (flags & FJSON_TO_STRING_SPACED)
 			printbuf_memappend_char(pb, ' ');
 		indent(pb, level+1, flags);
 		printbuf_memappend_char(pb, '\"');
 		fjson_escape_str(pb, iter.key);
-		if (flags & FJSON_C_TO_STRING_SPACED)
+		if (flags & FJSON_TO_STRING_SPACED)
 			printbuf_memappend_no_nul(pb, "\": ", 3);
 		else
 			printbuf_memappend_no_nul(pb, "\":", 2);
@@ -410,13 +410,13 @@ static int fjson_object_object_to_json_string(struct fjson_object* jso,
 		else
 			iter.val->_to_json_string(iter.val, pb, level+1,flags);
 	}
-	if (flags & FJSON_C_TO_STRING_PRETTY)
+	if (flags & FJSON_TO_STRING_PRETTY)
 	{
 		if (had_children)
 			printbuf_memappend_no_nul(pb, "\n",1);
 		indent(pb,level,flags);
 	}
-	if (flags & FJSON_C_TO_STRING_SPACED)
+	if (flags & FJSON_TO_STRING_SPACED)
 		printbuf_memappend_no_nul(pb, /*{*/ " }", 2);
 	else
 		printbuf_memappend_char(pb, /*{*/ '}');
@@ -478,11 +478,11 @@ void fjson_object_object_add_ex(struct fjson_object* jso,
 	fjson_object *existing_value = NULL;
 	struct lh_entry *existing_entry;
 	const unsigned long hash = lh_get_hash(jso->o.c_object, (void*)key);
-	existing_entry = (opts & FJSON_C_OBJECT_ADD_KEY_IS_NEW) ? NULL : 
+	existing_entry = (opts & FJSON_OBJECT_ADD_KEY_IS_NEW) ? NULL : 
 			      lh_table_lookup_entry_w_hash(jso->o.c_object, (void*)key, hash);
 	if (!existing_entry)
 	{
-		void *const k = (opts & FJSON_C_OBJECT_KEY_IS_CONSTANT) ?
+		void *const k = (opts & FJSON_OBJECT_KEY_IS_CONSTANT) ?
 					(void*)key : strdup(key);
 		lh_table_insert_w_hash(jso->o.c_object, k, val, hash, opts);
 		return;
@@ -717,7 +717,7 @@ static int fjson_object_double_to_json_string(struct fjson_object* jso,
   } else {
     p = strchr(buf, '.');
   }
-  if (p && (flags & FJSON_C_TO_STRING_NOZERO)) {
+  if (p && (flags & FJSON_TO_STRING_NOZERO)) {
     /* last useful digit, always keep 1 zero */
     p++;
     for (q=p ; *q ; q++) {
@@ -927,7 +927,7 @@ static int fjson_object_array_to_json_string(struct fjson_object* jso,
 	int had_children = 0;
 	int ii;
 	printbuf_memappend_char(pb, '[');
-	if (flags & FJSON_C_TO_STRING_PRETTY)
+	if (flags & FJSON_TO_STRING_PRETTY)
 		printbuf_memappend_char(pb, '\n');
 	for(ii=0; ii < fjson_object_array_length(jso); ii++)
 	{
@@ -935,11 +935,11 @@ static int fjson_object_array_to_json_string(struct fjson_object* jso,
 		if (had_children)
 		{
 			printbuf_memappend_char(pb, ',');
-			if (flags & FJSON_C_TO_STRING_PRETTY)
+			if (flags & FJSON_TO_STRING_PRETTY)
 				printbuf_memappend_char(pb, '\n');
 		}
 		had_children = 1;
-		if (flags & FJSON_C_TO_STRING_SPACED)
+		if (flags & FJSON_TO_STRING_SPACED)
 			printbuf_memappend_char(pb, ' ');
 		indent(pb, level + 1, flags);
 		val = fjson_object_array_get_idx(jso, ii);
@@ -948,14 +948,14 @@ static int fjson_object_array_to_json_string(struct fjson_object* jso,
 		else
 			val->_to_json_string(val, pb, level+1, flags);
 	}
-	if (flags & FJSON_C_TO_STRING_PRETTY)
+	if (flags & FJSON_TO_STRING_PRETTY)
 	{
 		if (had_children)
 			printbuf_memappend_char(pb, '\n');
 		indent(pb,level,flags);
 	}
 
-	if (flags & FJSON_C_TO_STRING_SPACED)
+	if (flags & FJSON_TO_STRING_SPACED)
 		printbuf_memappend_no_nul(pb, " ]", 2);
 	else
 		printbuf_memappend_char(pb, ']');

--- a/json_object.h
+++ b/json_object.h
@@ -35,13 +35,13 @@ extern "C" {
  * fjson_object_to_file_ext() functions which causes the output
  * to have no extra whitespace or formatting applied.
  */
-#define FJSON_C_TO_STRING_PLAIN      0
+#define FJSON_TO_STRING_PLAIN      0
 /**
  * A flag for the fjson_object_to_json_string_ext() and
  * fjson_object_to_file_ext() functions which causes the output to have
  * minimal whitespace inserted to make things slightly more readable.
  */
-#define FJSON_C_TO_STRING_SPACED     (1<<0)
+#define FJSON_TO_STRING_SPACED     (1<<0)
 /**
  * A flag for the fjson_object_to_json_string_ext() and
  * fjson_object_to_file_ext() functions which causes
@@ -50,7 +50,7 @@ extern "C" {
  * See the "Two Space Tab" option at http://jsonformatter.curiousconcept.com/
  * for an example of the format.
  */
-#define FJSON_C_TO_STRING_PRETTY     (1<<1)
+#define FJSON_TO_STRING_PRETTY     (1<<1)
 /**
  * A flag for the fjson_object_to_json_string_ext() and
  * fjson_object_to_file_ext() functions which causes
@@ -58,11 +58,11 @@ extern "C" {
  *
  * Instead of a "Two Space Tab" this gives a single tab character.
  */
-#define FJSON_C_TO_STRING_PRETTY_TAB (1<<3)
+#define FJSON_TO_STRING_PRETTY_TAB (1<<3)
 /**
  * A flag to drop trailing zero for float values
  */
-#define FJSON_C_TO_STRING_NOZERO     (1<<2)
+#define FJSON_TO_STRING_NOZERO     (1<<2)
 
 /**
  * A flag for the fjson_object_object_add_ex function which
@@ -74,7 +74,7 @@ extern "C" {
  * knows for sure the key values are unique (e.g. because the
  * code adds a well-known set of constant key values).
  */
-#define FJSON_C_OBJECT_ADD_KEY_IS_NEW (1<<1)
+#define FJSON_OBJECT_ADD_KEY_IS_NEW (1<<1)
 /**
  * A flag for the fjson_object_object_add_ex function which
  * flags the key as being constant memory. This means that
@@ -90,9 +90,9 @@ extern "C" {
  * key is given as a real constant value in the function
  * call, e.g. as in
  *   fjson_object_object_add_ex(obj, "ip", json,
- *       FJSON_C_OBJECT_KEY_IS_CONSTANT);
+ *       FJSON_OBJECT_KEY_IS_CONSTANT);
  */
-#define FJSON_C_OBJECT_KEY_IS_CONSTANT (1<<2)
+#define FJSON_OBJECT_KEY_IS_CONSTANT (1<<2)
 
 #undef FALSE
 #define FALSE ((fjson_bool)0)
@@ -199,7 +199,7 @@ extern enum fjson_type fjson_object_get_type(struct fjson_object *obj);
 
 
 /** Stringify object to json format.
- * Equivalent to fjson_object_to_json_string_ext(obj, FJSON_C_TO_STRING_SPACED)
+ * Equivalent to fjson_object_to_json_string_ext(obj, FJSON_TO_STRING_SPACED)
  * The pointer you get is an internal of your json object. You don't
  * have to free it, later use of fjson_object_put() should be sufficient.
  * If you can not ensure there's no concurrent access to *obj use
@@ -212,7 +212,7 @@ extern const char* fjson_object_to_json_string(struct fjson_object *obj);
 /** Stringify object to json format
  * @see fjson_object_to_json_string() for details on how to free string.
  * @param obj the fjson_object instance
- * @param flags formatting options, see FJSON_C_TO_STRING_PRETTY and other constants
+ * @param flags formatting options, see FJSON_TO_STRING_PRETTY and other constants
  * @returns a string in JSON format
  */
 extern const char* fjson_object_to_json_string_ext(struct fjson_object *obj, int
@@ -318,7 +318,7 @@ extern void fjson_object_object_add(struct fjson_object* obj, const char *key,
  *
  * The semantics are identical to fjson_object_object_add, except that an
  * additional flag fields gives you more control over some detail aspects
- * of processing. See the description of FJSON_C_OBJECT_ADD_* flags for more
+ * of processing. See the description of FJSON_OBJECT_ADD_* flags for more
  * details.
  *
  * @param obj the fjson_object instance

--- a/json_util.c
+++ b/json_util.c
@@ -159,7 +159,7 @@ int fjson_object_to_file_ext(const char *filename, struct fjson_object *obj, int
 
 int fjson_object_to_file(const char *filename, struct fjson_object *obj)
 {
-  return fjson_object_to_file_ext(filename, obj, FJSON_C_TO_STRING_PLAIN);
+  return fjson_object_to_file_ext(filename, obj, FJSON_TO_STRING_PLAIN);
 }
 
 int fjson_parse_double(const char *buf, double *retval)

--- a/linkhash.c
+++ b/linkhash.c
@@ -40,10 +40,10 @@ int
 fjson_global_set_string_hash(const int h)
 {
 	switch(h) {
-	case FJSON_C_STR_HASH_DFLT:
+	case FJSON_STR_HASH_DFLT:
 		char_hash_fn = lh_char_hash;
 		break;
-	case FJSON_C_STR_HASH_PERLLIKE:
+	case FJSON_STR_HASH_PERLLIKE:
 		char_hash_fn = lh_perllike_str_hash;
 		break;
 	default:
@@ -519,7 +519,7 @@ void lh_table_resize(struct lh_table *t, int new_size)
 	while(ent) {
 		lh_table_insert_w_hash(new_t, ent->k, ent->v,
 			lh_get_hash(new_t, ent->k),
-			(ent->k_is_constant) ? FJSON_C_OBJECT_KEY_IS_CONSTANT : 0 );
+			(ent->k_is_constant) ? FJSON_OBJECT_KEY_IS_CONSTANT : 0 );
 		ent = ent->next;
 	}
 	if(t->table != t->dflt_table)
@@ -559,7 +559,7 @@ int lh_table_insert_w_hash(struct lh_table *t, void *k, const void *v, const uns
 	}
 
 	t->table[n].k = k;
-	t->table[n].k_is_constant = (opts & FJSON_C_OBJECT_KEY_IS_CONSTANT);
+	t->table[n].k_is_constant = (opts & FJSON_OBJECT_KEY_IS_CONSTANT);
 	t->table[n].v = v;
 	t->count++;
 

--- a/linkhash.h
+++ b/linkhash.h
@@ -48,16 +48,16 @@ extern "C" {
 /**
  * default string hash function
  */
-#define FJSON_C_STR_HASH_DFLT 0
+#define FJSON_STR_HASH_DFLT 0
 
 /**
  * perl-like string hash function
  */
-#define FJSON_C_STR_HASH_PERLLIKE 1
+#define FJSON_STR_HASH_PERLLIKE 1
 
 /**
  * This function sets the hash function to be used for strings.
- * Must be one of the FJSON_C_STR_HASH_* values.
+ * Must be one of the FJSON_STR_HASH_* values.
  * @returns 0 - ok, -1 if parameter was invalid
  */
 int fjson_global_set_string_hash(const int h);

--- a/tests/parse_flags.c
+++ b/tests/parse_flags.c
@@ -16,9 +16,9 @@ static struct {
 	const char *arg;
 	int flag;
 } format_args[] = {
-	{ "plain", FJSON_C_TO_STRING_PLAIN },
-	{ "spaced", FJSON_C_TO_STRING_SPACED },
-	{ "pretty", FJSON_C_TO_STRING_PRETTY },
+	{ "plain", FJSON_TO_STRING_PLAIN },
+	{ "spaced", FJSON_TO_STRING_SPACED },
+	{ "pretty", FJSON_TO_STRING_PRETTY },
 };
 
 #ifndef NELEM

--- a/tests/test_locale.c
+++ b/tests/test_locale.c
@@ -25,7 +25,7 @@ int main(int __attribute__((unused)) argc, char __attribute__((unused)) **argv)
 
 	new_obj = fjson_tokener_parse("[1.2,3.4,123456.78,5.0,2.3e10]");
 	printf("new_obj.to_string()=%s\n", fjson_object_to_json_string(new_obj));
-	printf("new_obj.to_string()=%s\n", fjson_object_to_json_string_ext(new_obj,FJSON_C_TO_STRING_NOZERO));
+	printf("new_obj.to_string()=%s\n", fjson_object_to_json_string_ext(new_obj,FJSON_TO_STRING_NOZERO));
 	fjson_object_put(new_obj);
 	return 0;
 }


### PR DESCRIPTION
The _C was a left-over from the "json-c" name.

closes https://github.com/rsyslog/libfastjson/issues/20