### PR TITLE
build: stop changing behaviour of standard targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,17 +49,8 @@ libfastjson_la_SOURCES = \
 	random_seed.c
 
 
-distclean-local:
-	-rm -rf $(testsubdir)
-	-rm -rf config.h.in~ Makefile.in aclocal.m4 autom4te.cache/ config.guess config.sub depcomp install-sh ltmain.sh missing
-	-rm -f INSTALL test-driver tests/Makefile.in compile
-
-maintainer-clean-local:
-	-rm -rf configure
-
 uninstall-local:
 	rm -rf "$(DESTDIR)@includedir@/libfastjson"
-	rm -f "$(DESTDIR)@includedir@/json"
 
 ANDROID_CFLAGS = -I$(top_srcdir) -DHAVE_CONFIG_H
 


### PR DESCRIPTION
Don't change standard behaviour of 'distclean' and 'maintainer-clean'.
This is annoying for users which expect the default behaviour of a
standard autoconf/automake project.
See [1] which e.g. is explicit about 'maintainer-clean' *not* removing
anything which is necessary to run configure.

The current behaviour breaks the Debian tools when trying to build twice
in a row, as the 'distclean' step removes too many files.

[1] https://www.gnu.org/prep/standards/html_node/Standard-Targets.html