### PR TITLE
add a source code compatibility layer to json-c

### DIFF
--- a/DIFFERENCES
+++ b/DIFFERENCES
@@ -1,3 +1,10 @@
+Compatibility Layer
+libfastjson offers some limited source code compatiblity to
+json-c via preprocessor macros. They are currently primarily
+targeted at what the rsyslog family of projects need.
+Also, they do not work work properly with ./configure checks.
+This is due to the way autotools checks for functions.
+
 Differences to json-c
 
 * we do NOT handle NUL characters inside strings or names

--- a/json.h
+++ b/json.h
@@ -4,6 +4,8 @@
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
  * Copyright (c) 2009 Hewlett-Packard Development Company, L.P.
+ * Copyright (c) 2016 Adiscon GmbH
+ * Rainer Gerhards <rgerhards@adiscon.com>
  *
  * This library is free software; you can redistribute it and/or modify
  * it under the terms of the MIT license. See COPYING for details.

--- a/json_object.h
+++ b/json_object.h
@@ -691,6 +691,89 @@ extern int fjson_object_get_string_len(struct fjson_object *obj);
  * @returns int
  */
 int fjson_object_get_member_count(struct fjson_object *jso);
+
+
+/* The following is a source code compatibility layer
+ * in regard to json-c.
+ * It currently is aimed at the rsyslog family of projects,
+ * we may extend or drop it later.
+ */
+#ifndef FJSON_NATIVE_API_ONLY
+
+#define JSON_C_TO_STRING_PLAIN      FJSON_TO_STRING_PLAIN
+#define JSON_C_TO_STRING_SPACED FJSON_TO_STRING_SPACED
+#define JSON_C_TO_STRING_PRETTY FJSON_TO_STRING_PRETTY
+#define JSON_C_TO_STRING_PRETTY_TAB FJSON_TO_STRING_PRETTY_TAB
+#define JSON_C_TO_STRING_NOZERO FJSON_TO_STRING_NOZERO
+#define JSON_C_OBJECT_ADD_KEY_IS_NEW FJSON_OBJECT_ADD_KEY_IS_NEW
+#define JSON_C_OBJECT_KEY_IS_CONSTANT FJSON_OBJECT_KEY_IS_CONSTANT
+
+
+/* forward structure definitions */
+
+#if 0
+typedef int fjson_bool;
+typedef struct printbuf printbuf;
+typedef struct lh_table lh_table;
+typedef struct array_list array_list;
+typedef struct fjson_object fjson_object;
+typedef struct fjson_tokener fjson_tokener;
+#endif
+
+#define json_bool fjson_bool
+#define json_type fjson_type
+#define json_type_null fjson_type_null
+#define json_type_boolean fjson_type_boolean
+#define json_type_double fjson_type_double
+#define json_type_int fjson_type_int
+#define json_type_object fjson_type_object
+#define json_type_array fjson_type_array
+#define json_type_string fjson_type_string
+#define json_object_iter fjson_object_iter
+
+#define json_object fjson_object
+
+#define json_object_get fjson_object_get
+#define json_object_put fjson_object_put
+#define json_object_is_type fjson_object_is_type
+#define json_object_get_type(x) fjson_object_get_type((x))
+#define json_object_to_json_string(x) fjson_object_to_json_string((x))
+#define json_object_to_json_string_ext(a, b) fjson_object_to_json_string_ext((a), (b))
+#define json_object_new_object() fjson_object_new_object()
+#define json_object_object_length(a) fjson_object_object_length((a))
+#define json_object_object_add(a, b, c) fjson_object_object_add((a), (b), (c))
+#define json_object_object_add_ex fjson_object_object_add_ex
+#define json_object_object_get_ex fjson_object_object_get_ex
+#define json_object_object_foreach fjson_object_object_foreach
+#define json_object_object_foreachC fjson_object_object_foreachC
+#define json_object_object_get fjson_object_object_get
+#define json_object_object_del fjson_object_object_del
+#define json_object_get_object fjson_object_get_object
+#define json_object_new_array fjson_object_new_array
+#define json_object_get_array fjson_object_get_array
+#define json_object_array_length fjson_object_array_length
+#define json_object_array_sort fjson_object_array_sort
+#define json_object_array_bsearch fjson_object_array_bsearch
+#define json_object_array_add fjson_object_array_add
+#define json_object_array_put_idx fjson_object_array_put_idx
+#define json_object_array_get_idx fjson_object_array_get_idx
+#define json_object_new_boolean fjson_object_new_boolean
+#define json_object_get_boolean fjson_object_get_boolean
+#define json_object_new_int fjson_object_new_int
+#define json_object_new_int64 fjson_object_new_int64
+#define json_object_new_double fjson_object_new_double
+#define json_object_new_double_s fjson_object_new_double_s
+#define json_object_get_double fjson_object_get_double
+#define json_object_new_string fjson_object_new_string
+#define json_object_new_string_len fjson_object_new_string_len
+#define json_object_get_string fjson_object_get_string
+#define json_object_get_int fjson_object_get_int
+#define json_object_get_int64 fjson_object_get_int64
+#define json_object_get_string_len fjson_object_get_string_len
+#define json_object_get_member_count fjson_object_get_member_count
+
+
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -68,7 +68,7 @@ static const int fjson_true_str_len = sizeof(fjson_true_str) - 1;
 static const char fjson_false_str[] = "false";
 static const int fjson_false_str_len = sizeof(fjson_false_str) - 1;
 
-static const char* fjson_tokener_errors[] = {
+const char* fjson_tokener_errors[15] = {
   "success",
   "continue",
   "nesting too deep",

--- a/json_tokener.h
+++ b/json_tokener.h
@@ -201,6 +201,21 @@ if (tok->char_offset < stringlen) // XXX shouldn't access internal fields
 extern struct fjson_object* fjson_tokener_parse_ex(struct fjson_tokener *tok,
 						 const char *str, int len);
 
+#ifndef FJSON_NATIVE_API_ONLY
+#define json_tokener fjson_tokener
+#define json_tokener_error fjson_tokener_error
+extern const char* fjson_tokener_errors[15];
+#define json_tokener_errors fjson_tokener_errors
+#define json_tokener_continue fjson_tokener_continue
+#define json_tokener_reset fjson_tokener_reset
+
+#define json_tokener_new() fjson_tokener_new()
+#define json_tokener_parse fjson_tokener_parse
+#define json_tokener_parse_ex(a, b, c) fjson_tokener_parse_ex((a), (b), (c))
+#define json_tokener_free(a) fjson_tokener_free((a))
+#define json_tokener_error_desc(a) fjson_tokener_error_desc((a))
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/json_util.h
+++ b/json_util.h
@@ -37,12 +37,15 @@ extern int fjson_object_to_file_ext(const char *filename, struct fjson_object *o
 extern int fjson_parse_int64(const char *buf, int64_t *retval);
 extern int fjson_parse_double(const char *buf, double *retval);
 
-
 /**
  * Return a string describing the type of the object.
  * e.g. "int", or "object", etc...
  */
 extern const char *fjson_type_to_name(enum fjson_type o_type);
+
+#ifndef FJSON_NATIVE_API_ONLY
+#define json_type_to_name fjson_type_to_name
+#endif
 
 #ifdef __cplusplus
 }

--- a/linkhash.h
+++ b/linkhash.h
@@ -333,6 +333,12 @@ static inline unsigned long lh_get_hash(const struct lh_table *t, const void *k)
 	return t->hash_fn(k);
 }
 
+#ifndef FJSON_NATIVE_API_ONLY
+#define JSON_C_STR_HASH_PERLLIKE FJSON_STR_HASH_PERLLIKE
+#define json_global_set_string_hash fjson_global_set_string_hash
+#endif
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
... primarily for rsyslog family of projects. This is needed for
smooth migration to new namespace. We can later decide if we
extend or drop that layer.

closes https://github.com/rsyslog/libfastjson/issues/31