### PR TITLE
Ax compiler flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,8 +24,11 @@ libfastjsoninclude_HEADERS = \
 	printbuf.h \
 	random_seed.h
 
-libfastjson_la_LDFLAGS = -version-info 3:0:0 -no-undefined @JSON_BSYMBOLIC_LDFLAGS@ \
-	-export-symbols-regex '^fjson_.*'
+libfastjson_la_LDFLAGS = \
+	-version-info 3:0:0 \
+	-export-symbols-regex '^fjson_.*' \
+	-no-undefined \
+	@JSON_BSYMBOLIC_LDFLAGS@
 
 libfastjson_la_SOURCES = \
 	arraylist.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,6 @@ libfastjsoninclude_HEADERS = \
 
 libfastjson_la_LDFLAGS = -version-info 3:0:0 -no-undefined @JSON_BSYMBOLIC_LDFLAGS@ \
 	-export-symbols-regex '^fjson_.*'
-libfastjson_la_CPPFLAGS = -Werror
 
 libfastjson_la_SOURCES = \
 	arraylist.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,8 @@ EXTRA_DIST = README.html
 
 SUBDIRS = . tests
 
-lib_LTLIBRARIES = libfastjson.la 
+lib_LTLIBRARIES = libfastjson.la
+noinst_LTLIBRARIES = libfastjson-internal.la
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libfastjson.pc
@@ -29,19 +30,21 @@ libfastjson_la_LDFLAGS = \
 	-export-symbols-regex '^fjson_.*' \
 	-no-undefined \
 	@JSON_BSYMBOLIC_LDFLAGS@
+libfastjson_la_LIBADD = libfastjson-internal.la
 
 libfastjson_la_SOURCES = \
-	arraylist.c \
-	debug.c \
 	json_version.c \
 	json_object.c \
 	json_object_iterator.c \
 	json_tokener.c \
-	json_util.c \
+	json_util.c
+
+libfastjson_internal_la_SOURCES = \
+	arraylist.c \
+	debug.c \
 	linkhash.c \
 	printbuf.c \
 	random_seed.c
-
 
 uninstall-local:
 	rm -rf "$(DESTDIR)@includedir@/libfastjson"

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,18 +12,13 @@ pkgconfig_DATA = libfastjson.pc
 libfastjsonincludedir = $(includedir)/libfastjson
 libfastjsoninclude_HEADERS = \
 	atomic.h \
-	arraylist.h \
-	debug.h \
 	json.h \
 	json_inttypes.h \
 	json_object.h \
 	json_object_iterator.h \
 	json_object_private.h \
 	json_tokener.h \
-	json_util.h \
-	linkhash.h \
-	printbuf.h \
-	random_seed.h
+	json_util.h
 
 libfastjson_la_LDFLAGS = \
 	-version-info 3:0:0 \
@@ -40,10 +35,15 @@ libfastjson_la_SOURCES = \
 	json_util.c
 
 libfastjson_internal_la_SOURCES = \
+	arraylist.h \
 	arraylist.c \
+	debug.h \
 	debug.c \
+	linkhash.h \
 	linkhash.c \
+	printbuf.h \
 	printbuf.c \
+	random_seed.h \
 	random_seed.c
 
 uninstall-local:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 
-EXTRA_DIST = README.html \
-	atomic.h
+EXTRA_DIST = README.html
+
 SUBDIRS = . tests
 
 lib_LTLIBRARIES = libfastjson.la 
@@ -10,6 +10,7 @@ pkgconfig_DATA = libfastjson.pc
 
 libfastjsonincludedir = $(includedir)/libfastjson
 libfastjsoninclude_HEADERS = \
+	atomic.h \
 	arraylist.h \
 	debug.h \
 	json.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ libfastjsoninclude_HEADERS = \
 	json_tokener.h \
 	json_util.h
 
+libfastjson_la_CFLAGS = $(WARN_CFLAGS)
 libfastjson_la_LDFLAGS = \
 	-version-info 3:0:0 \
 	-export-symbols-regex '^fjson_.*' \
@@ -34,6 +35,7 @@ libfastjson_la_SOURCES = \
 	json_tokener.c \
 	json_util.c
 
+libfastjson_internal_la_CFLAGS = $(WARN_CFLAGS)
 libfastjson_internal_la_SOURCES = \
 	arraylist.h \
 	arraylist.c \

--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,8 @@ AS_IF([test "x$enable_Bsymbolic" = "xcheck"],
 AS_IF([test "x$enable_Bsymbolic" = "xyes"], [JSON_BSYMBOLIC_LDFLAGS=-Wl[,]-Bsymbolic-functions])
 AC_SUBST(JSON_BSYMBOLIC_LDFLAGS)
 
+AX_COMPILER_FLAGS
+
 AC_CONFIG_FILES([
 Makefile
 libfastjson.pc

--- a/json.h
+++ b/json.h
@@ -17,9 +17,6 @@
 extern "C" {
 #endif
 
-#include "debug.h"
-#include "linkhash.h"
-#include "arraylist.h"
 #include "json_util.h"
 #include "json_object.h"
 #include "json_tokener.h"

--- a/json_object_iterator.c
+++ b/json_object_iterator.c
@@ -24,6 +24,9 @@
 
 #include "json_object_iterator.h"
 
+#include "debug.h"
+#include "linkhash.h"
+
 /**
  * How It Works
  *

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,8 @@
 LDADD = $(top_builddir)/libfastjson.la \
         $(top_builddir)/libfastjson-internal.la
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 TESTS=
 TESTS+= test1.test
 TESTS+= test2.test

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,6 @@
 
-LDADD= $(LIBJSON_LA)
-
-LIBJSON_LA=$(top_builddir)/libfastjson.la
+LDADD = $(top_builddir)/libfastjson.la \
+        $(top_builddir)/libfastjson-internal.la
 
 TESTS=
 TESTS+= test1.test
@@ -29,8 +28,8 @@ TESTS += chk_version
 check_PROGRAMS += chk_version
 chk_version_SOURCES = chk_version.c
 
-test_printbuf_SOURCES = test_printbuf.c ../printbuf.c ../debug.c
-test_set_serializer_SOURCES = test_set_serializer.c ../printbuf.c
+test_printbuf_SOURCES = test_printbuf.c
+test_set_serializer_SOURCES = test_set_serializer.c
 
 # Note: handled by test1.test
 check_PROGRAMS += test1Formatted 

--- a/tests/parse_flags.c
+++ b/tests/parse_flags.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "../json.h"
 #include "parse_flags.h"

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -6,6 +6,8 @@
 #include <assert.h>
 
 #include "../json.h"
+#include "../debug.h"
+#include "../linkhash.h"
 #include "parse_flags.h"
 
 static int sort_fn (const void *j1, const void *j2)

--- a/tests/test2.c
+++ b/tests/test2.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "../json.h"
+#include "../debug.h"
 #include "parse_flags.h"
 
 #ifdef TEST_FORMATTED

--- a/tests/testReplaceExisting.c
+++ b/tests/testReplaceExisting.c
@@ -5,6 +5,8 @@
 #include <string.h>
 
 #include "../json.h"
+#include "../debug.h"
+#include "../linkhash.h"
 
 int main(int __attribute__((unused)) argc, char __attribute__((unused)) **argv)
 {

--- a/tests/test_charcase.c
+++ b/tests/test_charcase.c
@@ -7,6 +7,7 @@
 
 #include "../json.h"
 #include "../json_tokener.h"
+#include "../debug.h"
 
 static void test_case_parse(void);
 

--- a/tests/test_locale.c
+++ b/tests/test_locale.c
@@ -7,6 +7,7 @@
 
 #include "../json.h"
 #include "../json_tokener.h"
+#include "../debug.h"
 
 #ifdef HAVE_LOCALE_H
 #include <locale.h>

--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -7,6 +7,7 @@
 
 #include "../json.h"
 #include "../json_tokener.h"
+#include "../debug.h"
 
 static void test_basic_parse(void);
 static void test_verbose_parse(void);

--- a/tests/test_set_serializer.c
+++ b/tests/test_set_serializer.c
@@ -5,6 +5,7 @@
 
 #include "../json.h"
 #include "../printbuf.h"
+#include "../debug.h"
 
 struct myinfo {
 	int value;


### PR DESCRIPTION
This commit re-introduces support for Werror and also enables a bunch of additional warnings.
So expect the build to break if you compile from git where "error" is the default.