### PR TITLE
doc: fix libfastjson GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Make sure you have a complete `libtool` install, including `libtoolize`.
 `libfastjson` GitHub repo: https://github.com/rsyslog/libfastjson
 
 ```bash
-$ git clone https://github.com/libfastjson/libfastjson.git
+$ git clone https://github.com/rsyslog/libfastjson.git
 $ cd libfastjson
 $ sh autogen.sh
 ```


### PR DESCRIPTION
Trivial fix.
Related to that, should we drop README.html?
atm we have README (empty), README.md and README.html. That's a bit confusing imho.