### PR TITLE
remove [f]json_object_get_object() API

### DIFF
--- a/DIFFERENCES
+++ b/DIFFERENCES
@@ -37,6 +37,10 @@ Differences to json-c
   especially let us know why you think this is important to the
   community at large. Thanks.
   * [f]json_c_version_num()
+  * [f]json_object_get_object()
+    It returns a hash table, which exposes an implementation detail
+    that a caller should never know about. Most often, this can cleanly
+    be replaced by the regular json_object_iter_* API.
 
 * renamed API calls:
   * all calls have been added an "f" in the front

--- a/json_object.c
+++ b/json_object.c
@@ -450,7 +450,7 @@ struct fjson_object* fjson_object_new_object(void)
 	return jso;
 }
 
-struct lh_table* fjson_object_get_object(struct fjson_object *jso)
+struct lh_table* _fjson_object_get_object(struct fjson_object *jso)
 {
 	if (!jso)
 		return NULL;

--- a/json_object.h
+++ b/json_object.h
@@ -280,12 +280,6 @@ fjson_object_to_json_string_fn fjson_object_userdata_to_json_string;
  */
 extern struct fjson_object* fjson_object_new_object(void);
 
-/** Get the hashtable of a fjson_object of type fjson_type_object
- * @param obj the fjson_object instance
- * @returns a linkhash
- */
-extern struct lh_table* fjson_object_get_object(struct fjson_object *obj);
-
 /** Get the size of an object in terms of the number of fields it has.
  * @param obj the fjson_object whose length to return
  */
@@ -695,7 +689,6 @@ typedef struct fjson_tokener fjson_tokener;
 #define json_object_object_foreachC fjson_object_object_foreachC
 #define json_object_object_get fjson_object_object_get
 #define json_object_object_del fjson_object_object_del
-#define json_object_get_object fjson_object_get_object
 #define json_object_new_array fjson_object_new_array
 #define json_object_get_array fjson_object_get_array
 #define json_object_array_length fjson_object_array_length

--- a/json_object_iterator.c
+++ b/json_object_iterator.c
@@ -62,6 +62,9 @@
 /// @note May not always be NULL
 static const void* kObjectEndIterValue = NULL;
 
+/* need access to internal object */
+extern struct lh_table* _fjson_object_get_object(struct fjson_object *obj);
+
 /**
  * ****************************************************************************
  */
@@ -73,7 +76,7 @@ fjson_object_iter_begin(struct fjson_object* obj)
 
     /// @note fjson_object_get_object will return NULL if passed NULL
     ///       or a non-fjson_type_object instance
-    pTable = fjson_object_get_object(obj);
+    pTable = _fjson_object_get_object(obj);
     JASSERT(NULL != pTable);
 
     /// @note For a pair-less Object, head is NULL, which matches our


### PR DESCRIPTION
This provides access directly to the object's hash table, which is
bad because the use of hash tables is an implementation detail and
as such a caller should not depend on it. Actually, we may even
remove hash tables in newer versions and/or introduce alternative
data stores.

closes https://github.com/rsyslog/libfastjson/issues/58