### PR TITLE
bump soversion in spite of API/ABI changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ libfastjsoninclude_HEADERS = \
 
 libfastjson_la_CFLAGS = $(WARN_CFLAGS)
 libfastjson_la_LDFLAGS = \
-	-version-info 3:0:0 \
+	-version-info 4:0:0 \
 	-export-symbols-regex '^fjson_.*' \
 	-no-undefined \
 	@JSON_BSYMBOLIC_LDFLAGS@


### PR DESCRIPTION
see also https://github.com/rsyslog/libfastjson/issues/12