### PR TITLE
testbench: tool was not building cleanly

### DIFF
--- a/tests/test_obj_iter-del.c
+++ b/tests/test_obj_iter-del.c
@@ -15,6 +15,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* this is a work-around until we manage to fix configure.ac */
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
 
 int main(int __attribute__((unused)) argc, char __attribute__((unused)) **argv)
 {


### PR DESCRIPTION
Was not detected due to prequisites obviously not 100% correct on CI env.