### PR TITLE
quote version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.52)
 
 # Process this file with autoconf to produce a configure script.
-AC_INIT([libfastjson], 0.99.3.master, [rsyslog@lists.adiscon.com])
+AC_INIT([libfastjson], [0.99.3.master], [rsyslog@lists.adiscon.com])
 AC_CONFIG_HEADER(config.h)
 
 AM_INIT_AUTOMAKE([subdir-objects])


### PR DESCRIPTION
This is actually *required* because the daily build scripts
depend on this type of quoting to create the daily build
version number (they require the closing brace in order to
avoid false positives when substituting the version number).