### PR TITLE
Fix duplicate include of config.h

### DIFF
--- a/tests/test4.c
+++ b/tests/test4.c
@@ -5,7 +5,6 @@
 #include "config.h"
 #include <stdio.h>
 #include <string.h>
-#include "config.h"
 
 /* this is a work-around until we manage to fix configure.ac */
 #pragma GCC diagnostic ignored "-Wdeclaration-after-statement"


### PR DESCRIPTION
This is a follow-up for commit b5b92ae341cf38d4bd19f662a011860136433262