### PR TITLE
Fix  PR #107, #106

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -132,7 +132,7 @@ static void fjson_escape_str(struct printbuf *pb, const char *str)
 {
 	const char *start_offset = str;
 	while(1) { /* broken below on 0-byte */
-		if(needsEscape[(int)*str]) {
+		if(needsEscape[*((unsigned char*)str)]) {
 			if(*str == '\0')
 				break;
 			if(str != start_offset)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,6 +5,7 @@ LDADD = $(top_builddir)/libfastjson.la \
 AM_CFLAGS = $(WARN_CFLAGS)
 
 TESTS=
+TESTS+= ucs_copyright_char.test
 TESTS+= test1.test
 TESTS+= test2.test
 TESTS+= test4.test
@@ -70,6 +71,7 @@ EXTRA_DIST += test2Formatted_plain.expected
 EXTRA_DIST += test2Formatted_pretty.expected
 EXTRA_DIST += test2Formatted_spaced.expected
 EXTRA_DIST += test4.expected
+EXTRA_DIST += ucs_copyright_char.expected
 EXTRA_DIST += test_cast.expected
 EXTRA_DIST += test_charcase.expected
 EXTRA_DIST += test_locale.expected

--- a/tests/ucs_copyright_char.c
+++ b/tests/ucs_copyright_char.c
@@ -1,0 +1,19 @@
+/* Copyright (C) 2016 by Rainer Gerhards 
+ * Released under ASL 2.0 */
+#include "config.h"
+#include <stdio.h>
+#include "../json_object.h"
+#include "../json_tokener.h"
+int main(void)
+{
+  const char *s;
+  json_object *json;
+
+  s = "{ \"foo\" : \"\u00a9\" }";
+
+  printf("string = %s\n", s);
+  json = json_tokener_parse(s);
+  printf("json = %s\n", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
+
+  json_object_put(json);
+}

--- a/tests/ucs_copyright_char.expected
+++ b/tests/ucs_copyright_char.expected
@@ -1,0 +1,4 @@
+string = { "foo" : "©" }
+json = {
+  "foo":"©"
+}

--- a/tests/ucs_copyright_char.test
+++ b/tests/ucs_copyright_char.test
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Common definitions
+if test -z "$srcdir"; then
+    srcdir="${0%/*}"
+    test "$srcdir" = "$0" && srcdir=.
+    test -z "$srcdir" && srcdir=.
+fi
+. "$srcdir/test-defs.sh"
+
+run_output_test ucs_copyright_char
+exit $?


### PR DESCRIPTION
bugfix: invalid Unicode escapes, could also potentially trigger segfault
They were caused by improper sign extension of signed char, leading to
invalid table access.

closes #107
closes #106