### PR TITLE
m4: fix detection of atomics

### DIFF
--- a/m4/atomic_operations.m4
+++ b/m4/atomic_operations.m4
@@ -9,9 +9,7 @@
 #
 AC_DEFUN([RS_ATOMIC_OPERATIONS],
 [AC_CACHE_CHECK([whether the compiler provides atomic builtins], [ap_cv_atomic_builtins],
-[AC_TRY_RUN([
-int main()
-{
+[AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[
     unsigned long val = 1010, tmp, *mem = &val;
 
     if (__sync_fetch_and_add(&val, 1010) != 1010 || val != 2020)
@@ -44,7 +42,7 @@ int main()
         return 1;
 
     return 0;
-}], [ap_cv_atomic_builtins=yes], [ap_cv_atomic_builtins=no], [ap_cv_atomic_builtins=no])])
+]])], [ap_cv_atomic_builtins=yes], [ap_cv_atomic_builtins=no])])
 
 if test "$ap_cv_atomic_builtins" = "yes"; then
     AC_DEFINE(HAVE_ATOMIC_BUILTINS, 1, [Define if compiler provides atomic builtins])

--- a/m4/atomic_operations_64bit.m4
+++ b/m4/atomic_operations_64bit.m4
@@ -9,9 +9,7 @@
 #
 AC_DEFUN([RS_ATOMIC_OPERATIONS_64BIT],
 [AC_CACHE_CHECK([whether the compiler provides atomic builtins for 64 bit data types], [ap_cv_atomic_builtins_64],
-[AC_TRY_RUN([
-int main()
-{
+[AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[
     unsigned long long val = 1010, tmp, *mem = &val;
 
     if (__sync_fetch_and_add(&val, 1010) != 1010 || val != 2020)
@@ -44,7 +42,7 @@ int main()
         return 1;
 
     return 0;
-}], [ap_cv_atomic_builtins_64=yes], [ap_cv_atomic_builtins_64=no], [ap_cv_atomic_builtins_64=no])])
+]])], [ap_cv_atomic_builtins_64=yes], [ap_cv_atomic_builtins_64=no])])
 
 if test "$ap_cv_atomic_builtins_64" = "yes"; then
     AC_DEFINE(HAVE_ATOMIC_BUILTINS64, 1, [Define if compiler provides 64 bit atomic builtins])


### PR DESCRIPTION
In cross-compilation, it is impossible to run code at configure time to
detect the target specifics.

As such, AC_TRY_RUN fails miserably to detect reliably that atomic
intrisics are present in a toolchain, and decides they are not just
because this is cross-compilation.

Instead of AC_TRY_RUN, use AC_LINK_IFELSE that does not need to actually
run code, since all we're interested in is whether the intrisics are
present (or not). Fix both the 32- and 64-bit variants, even if the
latter is not used currently.

Fixes build failures detected by the Buildroot autobuilders, like:
    http://autobuild.buildroot.org/results/23a/23ac0e742ed3a70ae4d038f8c9eadc23e708f671/build-end.log
    http://autobuild.buildroot.org/results/192/1923d0b570adba494f83747a9610ea6ec35f5223/build-end.log

and many other cases, espcially on architectures where such intrsics are
present, but where the toolchain does not have threads (and anyway, it
is much more efficient to use the intrisics rather than use mutexes).

Signed-off-by: "Yann E. MORIN" yann.morin.1998@free.fr
