### PR TITLE
add option for case-insensitive comparisons

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.52)
 
 # Process this file with autoconf to produce a configure script.
-AC_INIT([libfastjson], [0.99.6.master], [rsyslog@lists.adiscon.com])
+AC_INIT([libfastjson], [0.99.7.master], [rsyslog@lists.adiscon.com])
 # AIXPORT START: Detect the underlying OS
 unamestr=$(uname)
 AM_CONDITIONAL([AIX], [test x$unamestr = xAIX])

--- a/json.h
+++ b/json.h
@@ -42,6 +42,19 @@ extern "C" {
  * @param size new initial size for printbuf (formatting buffer)
  */
 extern void fjson_global_set_printbuf_initial_size(int size);
+
+/**
+ * Set case sensitive/insensitive comparison mode. If set to 0,
+ * comparisons for JSON keys will be case-insensitive. Otherwise,
+ * they will be case-sensitive.
+ * NOTE: the JSON standard demands case sensitivity. By turning
+ * this off, the JSON standard is not obeyed. Most importantly,
+ * if keys exists which only differ in case, only partial data
+ * access is possible. So use with care and only if you know
+ * exactly what you are doing!
+ */
+extern void fjson_global_do_case_sensitive_comparison(const int newval);
+
 /**
  * report the current libfastjson version
  */

--- a/json_object.c
+++ b/json_object.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004, 2005 Metaparadigm Pte. Ltd.
  * Michael Clark <michael@metaparadigm.com>
  * Copyright (c) 2009 Hewlett-Packard Development Company, L.P.
- * Copyright (c) 2015 Rainer Gerhards
+ * Copyright (c) 2015-2017 Rainer Gerhards
  *
  * This library is free software; you can redistribute it and/or modify
  * it under the terms of the MIT license. See COPYING for details.
@@ -29,6 +29,7 @@
 #include "atomic.h"
 #include "printbuf.h"
 #include "arraylist.h"
+#include "json.h"
 #include "json_object.h"
 #include "json_object_private.h"
 #include "json_object_iterator.h"
@@ -55,6 +56,11 @@ static fjson_object_to_json_string_fn fjson_object_double_to_json_string;
 static fjson_object_to_json_string_fn fjson_object_string_to_json_string;
 static fjson_object_to_json_string_fn fjson_object_array_to_json_string;
 
+static int do_case_sensitive_comparison = 1;
+void fjson_global_do_case_sensitive_comparison(const int newval)
+{
+	do_case_sensitive_comparison = newval;
+}
 
 /* helper for accessing the optimized string data component in fjson_object
  */
@@ -427,8 +433,13 @@ _fjson_find_child(struct fjson_object *const __restrict__ jso,
 	struct fjson_object_iterator it = fjson_object_iter_begin(jso);
 	struct fjson_object_iterator itEnd = fjson_object_iter_end(jso);
 	while (!fjson_object_iter_equal(&it, &itEnd)) {
-		if (!strcmp (key, fjson_object_iter_peek_name(&it)))
-			return _fjson_object_iter_peek_child(&it);
+		if (do_case_sensitive_comparison) {
+			if (!strcmp (key, fjson_object_iter_peek_name(&it)))
+				return _fjson_object_iter_peek_child(&it);
+		} else {
+			if (!strcasecmp (key, fjson_object_iter_peek_name(&it)))
+				return _fjson_object_iter_peek_child(&it);
+		}
 		fjson_object_iter_next(&it);
 	}
 	return NULL;


### PR DESCRIPTION
This permits to search for json keys in a case-sensitive way.
The default is "off", as this is against the JSON spec. However,
rsyslog needs this capability to increase usability inside the
variable system.

We add a new API call to switch between case-sensitive and
case-insensitive comparison, with case-sensitive being the default.