### PR TITLE
bugfix: constant key names not properly handled

### DIFF
--- a/CI/check_codestyle.sh
+++ b/CI/check_codestyle.sh
@@ -5,4 +5,4 @@ git clone https://github.com/rsyslog/codestyle
 cd codestyle
 gcc --std=c99 stylecheck.c -o stylecheck
 cd ../..
-find *.[ch] | xargs _tmp_stylecheck/codestyle/stylecheck
+find *.[ch] | xargs _tmp_stylecheck/codestyle/stylecheck -l 130

--- a/json_object.c
+++ b/json_object.c
@@ -510,7 +510,9 @@ void fjson_object_object_del(struct fjson_object* jso, const char *key)
 {
 	struct _fjson_child *const chld = _fjson_find_child(jso, key);
 	if (chld != NULL) {
-		free((void*)chld->k);
+		if(!chld->flags.k_is_constant) {
+			free((void*)chld->k);
+		}
 		fjson_object_put(chld->v);
 		chld->flags.k_is_constant = 0;
 		chld->k = NULL;

--- a/json_print.c
+++ b/json_print.c
@@ -181,7 +181,8 @@ static size_t buffer_printf(struct buffer *buffer, const char *format, ...)
 		va_start(arguments, format);
 
 		// format into the buffer, again
-		buffer->size += vsnprintf(buffer->buffer + buffer->filled, buffer->size - buffer->filled - 1, format, arguments);
+		buffer->size += vsnprintf(buffer->buffer + buffer->filled,
+			buffer->size - buffer->filled - 1, format, arguments);
 
 		// clean up varargs
 		va_end(arguments);
@@ -283,7 +284,8 @@ static size_t escape(const char *str, struct buffer *buffer)
 			case '\\':  result += buffer_append(buffer, "\\\\", 2); break;
 			case '/':   result += buffer_append(buffer, "\\/", 2); break;
 			default:
-				result += buffer_printf(buffer, "\\u00%c%c", fjson_hex_chars[*str >> 4], fjson_hex_chars[*str & 0xf]);
+				result += buffer_printf(buffer, "\\u00%c%c",
+					fjson_hex_chars[*str >> 4], fjson_hex_chars[*str & 0xf]);
 				break;
 			}
 			start_offset = ++str;

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -550,12 +550,14 @@ redo_char:
 
 							if (got_hi_surrogate) {
 								if (IS_LOW_SURROGATE(tok->ucs_char)) {
-									/* Recalculate the ucs_char, then fall thru to process normally */
+									/* Recalculate the ucs_char, then fall thru to process
+									   normally */
 									tok->ucs_char =
 									    DECODE_SURROGATE_PAIR(got_hi_surrogate,
 												  tok->ucs_char);
 								} else {
-									/* Hi surrogate was not followed by a low surrogate */
+									/* Hi surrogate was not followed by a low
+									 * surrogate */
 									/* Replace the hi and process the rest normally */
 									printbuf_memappend_fast(tok->pb,
 												(char *)
@@ -563,10 +565,11 @@ redo_char:
 												3);
 								}
 								got_hi_surrogate = 0;
-								/* clang static analyzer thins that got_hi_surrogate is never read,
-								 * however, it is read on each iteration. So I assume clang has a false
-								 * positive. We use the otherwise nonsense statement below to make it
-								 * happy.
+								/* clang static analyzer thins that got_hi_surrogate
+								 * is never read, * however, it is read on each
+								 * iteration. So I assume clang has a false positive.
+								 * We use the otherwise nonsense statement below to
+								 * make it happy.
 								 */
 								if (got_hi_surrogate) {
 								};
@@ -591,8 +594,9 @@ redo_char:
 								if ((tok->char_offset + 1 != len) &&
 								    (tok->char_offset + 2 != len) &&
 								    (str[1] == '\\') && (str[2] == 'u')) {
-									/* Advance through the 16 bit surrogate, and move on to the
-									 * next sequence. The next step is to process the following
+									/* Advance through the 16 bit surrogate, and
+									 * move on to the next sequence. The next
+									 * step is to process the following
 									 * characters.
 									 */
 									if (!ADVANCE_CHAR(str, tok)
@@ -615,11 +619,11 @@ redo_char:
 									}
 									tok->ucs_char = 0;
 									tok->st_pos = 0;
-									continue;	/* other fjson_tokener_state_escape_unicode */
+									continue;/* other fjson_tokener_state_escape_unicode */
 								} else {
-									/* Got a high surrogate without another sequence following
-									 * it.  Put a replacement char in for the hi surrogate
-									 * and pretend we finished.
+									/* Got a high surrogate without another sequence
+									 * following it.  Put a replacement char in for
+									 * the hi surrogate and pretend we finished.
 									 */
 									printbuf_memappend_fast(tok->pb,
 												(char *)


### PR DESCRIPTION
if fjson_object_object_add_ex() is used with option
FJSON_OBJECT_KEY_IS_CONSTANT, fjson_object_object_del() will still
try to delete the key name. Depending on use, this can lead to
double-free, use-after-free or no problem.

see also https://github.com/rsyslog/rsyslog/issues/1839
closes https://github.com/rsyslog/libfastjson/issues/148