### PR TITLE
AIX port : suppress warnings about unknown GCC pragmas

### DIFF
--- a/json_print.c
+++ b/json_print.c
@@ -13,7 +13,9 @@
 #include "config.h"
 
 /* this is a work-around until we manage to fix configure.ac */
+#ifndef _AIX
 #pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -44,8 +46,10 @@
  * rgerhards, 2017-04-11
  */
 #define  vasprintf rs_vasprintf
+#ifndef _AIX
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
 static int rs_vasprintf(char **buf, const char *fmt, va_list ap)
 {
 	int chars;
@@ -70,7 +74,9 @@ static int rs_vasprintf(char **buf, const char *fmt, va_list ap)
 
 	return chars;
 }
+#ifndef _AIX
 #pragma GCC diagnostic pop
+#endif
 #endif /* !HAVE_VASPRINTF */
 
 /**

--- a/printbuf.c
+++ b/printbuf.c
@@ -163,8 +163,10 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
  * rgerhards, 2017-04-11
  */
 #define  vasprintf rs_vasprintf
+#ifndef _AIX
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
 static int rs_vasprintf(char **buf, const char *fmt, va_list ap)
 {
 	int chars;
@@ -189,7 +191,9 @@ static int rs_vasprintf(char **buf, const char *fmt, va_list ap)
 
 	return chars;
 }
+#ifndef _AIX
 #pragma GCC diagnostic pop
+#endif
 #endif /* !HAVE_VASPRINTF */
 
 int sprintbuf(struct printbuf *p, const char *msg, ...)


### PR DESCRIPTION
Those warnings does not stop the build process but it is cleaner like this. 