### PR TITLE
Adding a function fjson_object_array_del_idx

### DIFF
--- a/arraylist.c
+++ b/arraylist.c
@@ -87,6 +87,22 @@ array_list_add(struct array_list *arr, void *data)
 	return array_list_put_idx(arr, arr->length, data);
 }
 
+/*
+ * Deleting the idx-th element in the array_list.
+ */
+void
+array_list_del_idx(struct array_list *const arr, const int idx)
+{
+	if (idx < 0 || idx >= arr->length) {
+		return;
+	}
+	if(arr->array[idx]) arr->free_fn(arr->array[idx]);
+	if (--arr->length > idx) {
+		memmove(arr->array + idx, arr->array + idx + 1, (arr->length - idx) * sizeof(void *));
+	}
+	return;
+}
+
 /* work around wrong compiler message: GCC and clang do
  * not handle sort_fn correctly if -Werror is given.
  */

--- a/arraylist.h
+++ b/arraylist.h
@@ -41,6 +41,9 @@ array_list_put_idx(struct array_list *al, int i, void *data);
 extern int
 array_list_add(struct array_list *al, void *data);
 
+extern void
+array_list_del_idx(struct array_list *const arr, const int idx);
+
 extern int
 array_list_length(struct array_list *al);
 

--- a/json_object.c
+++ b/json_object.c
@@ -1018,6 +1018,14 @@ struct fjson_object* fjson_object_array_get_idx(struct fjson_object *jso,
 	return (struct fjson_object*)array_list_get_idx(jso->o.c_array, idx);
 }
 
+/*
+ * Deleting the idx-th element in the array type object.
+ */
+void fjson_object_array_del_idx(struct fjson_object *jso, int idx)
+{
+	array_list_del_idx(jso->o.c_array, idx);
+}
+
 int fjson_object_get_member_count(struct fjson_object *jso)
 {
 	return jso->o.c_obj.nelem;

--- a/json_object.h
+++ b/json_object.h
@@ -489,6 +489,8 @@ extern int fjson_object_array_put_idx(struct fjson_object *obj, int idx,
 extern struct fjson_object* fjson_object_array_get_idx(struct fjson_object *obj,
 							 int idx);
 
+extern void fjson_object_array_del_idx(struct fjson_object *jso, int idx);
+
 /* fjson_bool type methods */
 
 /** Create a new empty fjson_object of type fjson_type_boolean
@@ -731,6 +733,7 @@ typedef struct fjson_tokener fjson_tokener;
 #define json_object_get_int64 fjson_object_get_int64
 #define json_object_get_string_len fjson_object_get_string_len
 #define json_object_get_member_count fjson_object_get_member_count
+#define json_object_array_del_idx fjson_object_array_del_idx
 
 
 #endif


### PR DESCRIPTION
Adding "void fjson_object_array_del_idx(struct fjson_object *jso, int idx)",
which deletes the idx-th element in the array type object.

This patch is a part of work to support a requirement to remove empty json objects in parsing JSON.
    Adding parse_json_ex to grammar/rainerscript.c for supporting compact.
    Adding parameters variable, alt_variable and compact to mmjsonparse.
