### PR TITLE
"fix" "jump-misses-init" gcc-8 warning

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -396,6 +396,7 @@ fjson_child_get_empty_etry(struct fjson_object *const __restrict__ jso)
 {
 	struct _fjson_child *chld = NULL;
 	struct _fjson_child_pg *pg;
+	int pg_idx;
 
 	if (jso->o.c_obj.ndeleted > 0) {
 		/* we first fill deleted spots */
@@ -415,7 +416,7 @@ fjson_child_get_empty_etry(struct fjson_object *const __restrict__ jso)
 		goto done;
 	}
 
-	const int pg_idx = jso->o.c_obj.nelem % FJSON_OBJECT_CHLD_PG_SIZE;
+	pg_idx = jso->o.c_obj.nelem % FJSON_OBJECT_CHLD_PG_SIZE;
 	if (jso->o.c_obj.nelem > 0 && pg_idx == 0) {
 		if((pg = calloc(1, sizeof(struct _fjson_child_pg))) == NULL) {
 			errno = ENOMEM;


### PR DESCRIPTION
Actually, that warning is overly conservative, and so we
have changed the code in a somewhat suboptimal way to "fix"
it. In this spots, it's not that bad and we wanted to avoid
totally disabling this warning.

If it were more costly in terms of cleanness, we would probaly
have done that. Just mention it to tell anyone else the
cure is not really a good one, just selected due to the
circumstances in this special case.