### PR TITLE
bugfix for dangling pointer that causes segfault in array deletion and re-insertion.

### DIFF
--- a/arraylist.c
+++ b/arraylist.c
@@ -100,6 +100,7 @@ array_list_del_idx(struct array_list *const arr, const int idx)
 	if (--arr->length > idx) {
 		memmove(arr->array + idx, arr->array + idx + 1, (arr->length - idx) * sizeof(void *));
 	}
+	arr->array[arr->length] = NULL;
 	return;
 }
 


### PR DESCRIPTION
The other functions assume that the memory is either set to NULL or a valid JSON object. The array_list_del_idx function only moves the elements but does not set the pointer to null, which causes the same pointer to remain in the list (outside of arr->length). Then, when array_list_put_idx is called, the array_list_expand_internal leaps out, meaning that it has not set the indices outside of the requested length to 0. array_list_put_idx finds the pointer, tries to free it and a double free will be incurred because the actual element is still in the list.

Is triggered when an array is created, an element is removed and subsequently, a new element is inserted again. 

This can also be fixed by checking in the array_list_put_idx function, but as the arrays are explicitly calloc'ed and set to zero, this keeps the guarantee that either the memory is empty or has a valid json object. Makes the approach also less error-prone.