### PR TITLE
Add a function to get uint32_t representation of json-object

### DIFF
--- a/json_object.c
+++ b/json_object.c
@@ -647,13 +647,13 @@ struct fjson_object* fjson_object_new_int64(int64_t i)
 uint32_t fjson_object_get_uint(struct fjson_object *jso)
 {
 	int64_t cint = fjson_object_get_int64(jso);
-    if (errno) return 0;
+	if (errno) return 0;
 
-    if (cint > UINT32_MAX) return UINT32_MAX;
+	if (cint > UINT32_MAX) return UINT32_MAX;
 
-    if (cint < 0) return 0;
+	if (cint < 0) return 0;
 
-    return (uint32_t) cint;
+	return (uint32_t) cint;
 }
 
 int64_t fjson_object_get_int64(struct fjson_object *jso)

--- a/json_object.c
+++ b/json_object.c
@@ -644,6 +644,18 @@ struct fjson_object* fjson_object_new_int64(int64_t i)
 	return jso;
 }
 
+uint32_t fjson_object_get_uint(struct fjson_object *jso)
+{
+	int64_t cint = fjson_object_get_int64(jso);
+    if (errno) return 0;
+
+    if (cint > UINT32_MAX) return UINT32_MAX;
+
+    if (cint < 0) return 0;
+
+    return (uint32_t) cint;
+}
+
 int64_t fjson_object_get_int64(struct fjson_object *jso)
 {
 	int64_t cint;

--- a/json_object.h
+++ b/json_object.h
@@ -547,6 +547,22 @@ extern struct fjson_object* fjson_object_new_int64(int64_t i);
  */
 extern int32_t fjson_object_get_int(struct fjson_object *obj);
 
+/** Get the uint32 value of a fjson_object
+ *
+ * The type is coerced to a int if the passed object is not a int.
+ * double objects will return their integer conversion. Strings will be
+ * parsed as an integer. If no conversion exists then 0 is returned
+ * and errno is set to EINVAL. null is equivalent to 0 (no error values set)
+ *
+ * Note that integers are stored internally as 64-bit values.
+ * If the value of too big or too small to fit into unsigned 32-bit
+ * representation, UINT32_MAX or UINT32_MIN are returned, respectively.
+ *
+ * @param obj the fjson_object instance
+ * @returns an int
+ */
+extern uint32_t fjson_object_get_uint(struct fjson_object *obj);
+
 /** Get the int value of a fjson_object
  *
  * The type is coerced to a int64 if the passed object is not a int64.
@@ -730,6 +746,7 @@ typedef struct fjson_tokener fjson_tokener;
 #define json_object_new_string_len fjson_object_new_string_len
 #define json_object_get_string fjson_object_get_string
 #define json_object_get_int fjson_object_get_int
+#define json_object_get_uint fjson_object_get_uint
 #define json_object_get_int64 fjson_object_get_int64
 #define json_object_get_string_len fjson_object_get_string_len
 #define json_object_get_member_count fjson_object_get_member_count


### PR DESCRIPTION
Add a function to get uint32_t representation of json-object.

This will help fix rsyslog issue #4490 and #3394.