### PR TITLE
build: link libfastjson against libm for modf()

### DIFF
--- a/libfastjson.pc.in
+++ b/libfastjson.pc.in
@@ -8,5 +8,5 @@ Description: a fast JSON implementation in C
 Version: @VERSION@
 Requires:
 Libs.private: @LIBS@
-Libs:  -L${libdir} -lfastjson
+Libs:  -L${libdir} -lfastjson -lm
 Cflags: -I${includedir}/libfastjson


### PR DESCRIPTION
After upgrading to glibc-2.42, I noticed a runtime error in rsyslogd:

```
rsyslogd: Relink `/usr/lib64/libfastjson.so.4' with `/lib64/libm.so.6' for IFUNC symbol `modf'
Segmentation fault
```

This is due to changed modf implementation in glibc-2.42 causing IFUNC modf() resolution to fail at runtime in rsyslog due to missing direct link against libm.

Adding `-lm` to Libs ensures the shared library has a DT_NEEDED entry for libm.