### PR TITLE
Correctly link libfastjson against libm on glibc ≥ 2.42

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,9 +105,8 @@ AC_FUNC_VPRINTF
 AC_FUNC_MEMCMP
 AC_CHECK_FUNCS(strcasecmp strdup strerror snprintf vsnprintf vasprintf open vsyslog strncasecmp setlocale)
 
-if test "$ac_cv_have_decl_isnan" = "yes" ; then
-   AC_TRY_LINK([#include <math.h>], [float f = 0.0; return isnan(f)], [], [LIBS="$LIBS -lm"])
-fi
+# Force linking against libm (needed for modf on glibc >= 2.42)
+AC_CHECK_LIB([m], [modf], [LIBS="$LIBS -lm"],[AC_MSG_ERROR([libm (math library) is required for modf()])])
 
 #check if .section.gnu.warning accepts long strings (for __warn_references)
 AC_LANG_PUSH([C])

--- a/libfastjson.pc.in
+++ b/libfastjson.pc.in
@@ -8,5 +8,5 @@ Description: a fast JSON implementation in C
 Version: @VERSION@
 Requires:
 Libs.private: @LIBS@
-Libs:  -L${libdir} -lfastjson -lm
+Libs:  -L${libdir} -lfastjson
 Cflags: -I${includedir}/libfastjson


### PR DESCRIPTION
This PR fixes the handling of `modf()` and other math functions on systems using glibc-2.42 or later.

glibc ≥ 2.42 no longer provides implicit linkage for certain math functions (in particular the IFUNC-resolved modf()), which means
libraries must explicitly link against libm. The previous workaround introduced in #167 added `-lm` to the `pkg-config` file, but did not fix the underlying issue: libfastjson itself was not linking against `libm`.

This PR implements the correct solution. Thank you @mbiebl for the feedback!

Note: Autotools will automatically add `Libs.private:  -lm` to `libfastjson` if needed for static builds.