### PR TITLE
build: fix calloc transposed args

### DIFF
--- a/arraylist.c
+++ b/arraylist.c
@@ -31,7 +31,7 @@ array_list_new(array_list_free_fn *free_fn)
 	arr->size = ARRAY_LIST_DEFAULT_SIZE;
 	arr->length = 0;
 	arr->free_fn = free_fn;
-	if(!(arr->array = (void**)calloc(sizeof(void*), arr->size))) {
+	if(!(arr->array = (void**)calloc(arr->size, sizeof(void*)))) {
 		free(arr);
 		return NULL;
 	}

--- a/json_object.c
+++ b/json_object.c
@@ -214,7 +214,7 @@ static void fjson_object_generic_delete(struct fjson_object* jso)
 
 static struct fjson_object* fjson_object_new(const enum fjson_type o_type)
 {
-	struct fjson_object *const jso = (struct fjson_object*)calloc(sizeof(struct fjson_object), 1);
+	struct fjson_object *const jso = (struct fjson_object*)calloc(1, sizeof(struct fjson_object));
 	if (!jso)
 		return NULL;
 	jso->o_type = o_type;


### PR DESCRIPTION
fixes:
```c
    ../arraylist.c: In function 'array_list_new':
    ../arraylist.c:34:49: warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
       34 |         if(!(arr->array = (void**)calloc(sizeof(void*), arr->size))) {
          |                                                 ^~~~
    ../arraylist.c:34:49: note: earlier argument should specify number of elements, later size of each element
    ../json_object.c: In function 'fjson_object_new':
    ../json_object.c:217:78: warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
      217 |         struct fjson_object *const jso = (struct fjson_object*)calloc(sizeof(struct fjson_object), 1);
          |                                                                              ^~~~~~
    ../json_object.c:217:78: note: earlier argument should specify number of elements, later size of each element
``` 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed transposed calloc arguments to use (elements, size) and remove -Wcalloc-transposed-args build warnings. This makes allocations clearer and avoids potential issues.

- **Bug Fixes**
  - arraylist.c: use calloc(arr->size, sizeof(void*))
  - json_object.c: use calloc(1, sizeof(struct fjson_object))

<sup>Written for commit 490df884f038a43d4057ccf34803f254412a204a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

