### PR TITLE
tests: fix CI warning and distcheck failures

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,27 +4,29 @@ LDADD = $(top_builddir)/libfastjson.la \
 
 AM_CFLAGS = $(WARN_CFLAGS)
 
-TESTS=
-TESTS+= ucs_copyright_char.test
-TESTS+= test_float.test
-TESTS+= test1.test
-TESTS+= test2.test
-TESTS+= test4.test
-TESTS+= testReplaceExisting.test
-TESTS+= test_parse_int64.test
-TESTS+= test_cast.test
-TESTS+= test_parse.test
-TESTS+= test_locale.test
-TESTS+= test_charcase.test
-TESTS+= test_printbuf.test
-TESTS+= test_obj_iter-del.test
-TESTS+= test_object_object_add_ex.test
-TESTS+= test_many_subobj.test
-TESTS+= test_obj_obj_get_ex-null.test
+TESTS_DEFAULT=
+TESTS_DEFAULT+= ucs_copyright_char.test
+TESTS_DEFAULT+= test_float.test
+TESTS_DEFAULT+= test1.test
+TESTS_DEFAULT+= test2.test
+TESTS_DEFAULT+= test4.test
+TESTS_DEFAULT+= testReplaceExisting.test
+TESTS_DEFAULT+= test_parse_int64.test
+TESTS_DEFAULT+= test_cast.test
+TESTS_DEFAULT+= test_parse.test
+TESTS_DEFAULT+= test_locale.test
+TESTS_DEFAULT+= test_charcase.test
+TESTS_DEFAULT+= test_printbuf.test
+TESTS_DEFAULT+= test_obj_iter-del.test
+TESTS_DEFAULT+= test_object_object_add_ex.test
+TESTS_DEFAULT+= test_many_subobj.test
+TESTS_DEFAULT+= test_obj_obj_get_ex-null.test
 # we officially do NOT support NUL bytes (however, we may
 # later add a workaround to at least transparently pass them
 # through, thus I keep this as reference).
-#TESTS+= test_null.test 
+#TESTS_DEFAULT+= test_null.test
+
+TESTS = $(TESTS_DEFAULT)
 
 check_PROGRAMS=
 check_PROGRAMS += $(TESTS:.test=)
@@ -59,7 +61,9 @@ test_object_object_add_exFormatted_SOURCES = test_object_object_add_ex.c parse_f
 test_object_object_add_exFormatted_CPPFLAGS = -DTEST_FORMATTED
 
 EXTRA_DIST=
-EXTRA_DIST += $(TESTS)
+# Only shell test drivers are source-distribution inputs. chk_version is a
+# check program and must be built from its source in the distcheck tree.
+EXTRA_DIST += $(TESTS_DEFAULT)
 EXTRA_DIST += test-defs.sh
 EXTRA_DIST += test1.expected
 EXTRA_DIST += test1Formatted_plain.expected

--- a/tests/parse_flags.c
+++ b/tests/parse_flags.c
@@ -21,7 +21,7 @@ static struct {
 };
 
 #ifndef NELEM
-#define NELEM(x) (sizeof(x) / sizeof(&x[0]))
+#define NELEM(x) (sizeof(x) / sizeof((x)[0]))
 #endif
 
 int parse_flags(int argc, char **argv)


### PR DESCRIPTION
## Summary

- correct the test array-length macro so modern compilers do not reject it under `-Werror`
- keep executable test programs out of the source-distribution file list
- use rsyslog's named test-group convention for the distributed shell test drivers

## Why

The first GitHub Actions run exposed a long-standing invalid `sizeof` calculation and a `distcheck` failure caused by distributing the `chk_version` executable target.

## Validation

- `autoreconf -fvi`
- `./configure`
- `make check` (17 tests)
- `make distcheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI compile warnings and distcheck failures by correcting the array-length macro and distributing only shell test drivers. Also aligns test naming with rsyslog’s test-group convention and keeps `chk_version` out of the source tarball.

- **Bug Fixes**
  - Corrected `NELEM` to use `sizeof((x)[0])` so modern compilers don’t warn under `-Werror`.
  - Split `TESTS` into `TESTS_DEFAULT` and limited `EXTRA_DIST` to shell test drivers; exclude check programs like `chk_version` so they build in distcheck.
  - Adopted rsyslog-style named test-group convention for distributed shell test drivers.

<sup>Written for commit 1b6be54e2dd149ab12278d9bafd09a3af5dc8e6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rsyslog/libfastjson/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

