### PR TITLE
release: prepare 1.2609.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
-1.2???.0
- - TBD
+1.2609.0, 2026-09-01
+- speed up object member lookup by traversing child pages directly
+- fix buffered JSON dumping with zero-sized and small workspaces
+- ensure correct linking with libm on glibc 2.42 and later
+- fix transposed calloc() arguments that triggered newer compiler warnings
+- clarify string-buffer lifetime and thread-safety guarantees in the API docs
+- expand correctness, fuzzing, and cross-platform CI coverage
 1.2304.0, 2023-04-18
 - change of release number scheme, now like rsyslog
 - fix Fix CVE-2020-12762

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.52)
 
 # Process this file with autoconf to produce a configure script.
-AC_INIT([libfastjson], [1.2305.0.master], [rsyslog@lists.adiscon.com])
+AC_INIT([libfastjson], [1.2609.0], [rsyslog@lists.adiscon.com])
 # AIXPORT START: Detect the underlying OS
 unamestr=$(uname)
 AM_CONDITIONAL([AIX], [test x$unamestr = xAIX])


### PR DESCRIPTION
Prepares the 1.2609.0 release.

- sets the Autotools/package version to 1.2609.0
- maintains the ChangeLog from commits since v1.2304.0

Validation: `autoreconf -fvi && ./configure && make distcheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 1.2609.0 release by updating the package version in `configure.ac` and recording changes since v1.2304.0 in the `ChangeLog`.

<sup>Written for commit aaaa045bf5b31820e45e2a8a7bb1300da9ab9b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rsyslog/libfastjson/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

