### PR TITLE
release: start 1.2612.0 development cycle

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+1.2612.0
+ - TBD
 1.2609.0, 2026-09-01
 - speed up object member lookup by traversing child pages directly
 - fix buffered JSON dumping with zero-sized and small workspaces

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.52)
 
 # Process this file with autoconf to produce a configure script.
-AC_INIT([libfastjson], [1.2609.0], [rsyslog@lists.adiscon.com])
+AC_INIT([libfastjson], [1.2612.0.master], [rsyslog@lists.adiscon.com])
 # AIXPORT START: Detect the underlying OS
 unamestr=$(uname)
 AM_CONDITIONAL([AIX], [test x$unamestr = xAIX])


### PR DESCRIPTION
Starts the next development cycle after the 1.2609.0 release.

- sets the development version to `1.2612.0.master`
- adds the `1.2612.0` ChangeLog section

Validation: `autoreconf -fvi && ./configure` (generated pkg-config version: `1.2612.0.master`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts the 1.2612.0 development cycle after the 1.2609.0 release. Bumps the version in `configure.ac` to `1.2612.0.master` and adds a placeholder ChangeLog section for 1.2612.0.

<sup>Written for commit d351c34f7837dcb46f849c29889ef36902cadf12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rsyslog/libfastjson/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

